### PR TITLE
Add non-module algorithm generators

### DIFF
--- a/algorithms/bfs.nomod.js
+++ b/algorithms/bfs.nomod.js
@@ -1,0 +1,82 @@
+// Breadth-First Search on adjacency list graph (non-module build)
+(function (global) {
+  function bfs(input) {
+    if (!input || typeof input !== 'object') {
+      throw new Error('bfs expects { graph: Record<string, string[]>, start: string }');
+    }
+    const { graph = {}, start } = input;
+    const nodes = Array.from(
+      new Set(
+        Object.keys(graph).concat(
+          ...Object.values(graph).map((neighbors) => neighbors ?? [])
+        )
+      )
+    );
+    if (nodes.length === 0) {
+      return { steps: [], pseudocode: [], meta: {} };
+    }
+    if (!nodes.includes(start)) {
+      throw new Error('Start vertex must exist in the graph.');
+    }
+
+    const indexOf = new Map(nodes.map((node, idx) => [node, idx]));
+    const arr = nodes.map(() => 0); // visitation order (0 = unvisited)
+    const steps = [];
+    const pseudocode = [
+      'for each vertex v set visited[v] \u2190 false',
+      'create empty queue Q',
+      'enqueue(start)',
+      'visited[start] \u2190 true',
+      'while Q not empty',
+      '    v \u2190 dequeue(Q)',
+      '    for each neighbor w in Adj[v]',
+      '        if not visited[w]',
+      '            visited[w] \u2190 true',
+      '            enqueue(w)'
+    ];
+
+    const meta = {
+      complexity: { best: 'O(V + E)', avg: 'O(V + E)', worst: 'O(V + E)' },
+      space: 'O(V)',
+      notes: 'Operates on adjacency-list graphs. Steps record visitation order and queue contents.'
+    };
+
+    function push(sel = [], compare = [], swap = [], hlLines = [1], extra = {}) {
+      steps.push({ array: [...arr], sel, compare, swap, hlLines, nodes, ...extra });
+    }
+
+    const visited = new Set();
+    const queue = [];
+    let order = 0;
+
+    push([], [], [], [1], { queue: [...queue], visited: Array.from(visited) });
+
+    queue.push(start);
+    visited.add(start);
+    arr[indexOf.get(start)] = ++order;
+    push([indexOf.get(start)], [], [], [2, 3, 4], { queue: [...queue], visited: Array.from(visited) });
+
+    while (queue.length) {
+      const v = queue.shift();
+      const vIdx = indexOf.get(v);
+      push([vIdx], [], [], [5, 6], { queue: [...queue], visited: Array.from(visited), current: v });
+      const neighbors = graph[v] || [];
+      for (const w of neighbors) {
+        const wIdx = indexOf.get(w);
+        push([vIdx], [wIdx], [], [7, 8], { queue: [...queue], visited: Array.from(visited), current: v, neighbor: w });
+        if (!visited.has(w)) {
+          visited.add(w);
+          queue.push(w);
+          arr[wIdx] = ++order;
+          push([wIdx], [], [], [9, 10], { queue: [...queue], visited: Array.from(visited), current: v, neighbor: w });
+        }
+      }
+    }
+
+    return { steps, pseudocode, meta };
+  }
+
+  global.VisuDSA = global.VisuDSA || {};
+  global.VisuDSA.algorithms = global.VisuDSA.algorithms || {};
+  global.VisuDSA.algorithms.bfs = bfs;
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/algorithms/binarySearch.nomod.js
+++ b/algorithms/binarySearch.nomod.js
@@ -1,0 +1,66 @@
+// Binary Search with step generator + pseudocode mapping (non-module build)
+(function (global) {
+  function binarySearch(input) {
+    if (!input || !Array.isArray(input.array)) {
+      throw new Error('binarySearch expects { array: number[], target: number }');
+    }
+    const { array: source, target } = input;
+    const arr = [...source];
+    const steps = [];
+    const pseudocode = [
+      'low \u2190 0',
+      'high \u2190 n - 1',
+      'while low \u2264 high',
+      '    mid \u2190 \u230a(low + high) / 2\u230b',
+      '    if A[mid] = target return mid',
+      '    else if A[mid] < target',
+      '        low \u2190 mid + 1',
+      '    else',
+      '        high \u2190 mid - 1',
+      'return -1'
+    ];
+
+    const meta = {
+      complexity: { best: 'O(1)', avg: 'O(log n)', worst: 'O(log n)' },
+      space: 'O(1)',
+      notes: 'Requires a sorted array. Returns the index of the target or -1 if not found.'
+    };
+
+    function push(sel = [], compare = [], swap = [], hlLines = [1], extra = {}) {
+      steps.push({ array: [...arr], sel, compare, swap, hlLines, ...extra });
+    }
+
+    let low = 0;
+    let high = arr.length - 1;
+    let foundIndex = -1;
+
+    push([], [], [], [1, 2], { low, high });
+
+    while (low <= high) {
+      push([], [], [], [3]);
+      const mid = Math.floor((low + high) / 2);
+      push([mid], [], [], [4], { low, high, mid });
+      if (arr[mid] === target) {
+        foundIndex = mid;
+        push([mid], [], [], [5], { low, high, mid, result: mid });
+        break;
+      } else if (arr[mid] < target) {
+        low = mid + 1;
+        push([], [], [], [6, 7], { low, high, mid });
+      } else {
+        high = mid - 1;
+        push([], [], [], [8, 9], { low, high, mid });
+      }
+    }
+
+    if (foundIndex === -1) {
+      push([], [], [], [10], { result: -1 });
+    }
+
+    return { steps, pseudocode, meta };
+  }
+
+  global.VisuDSA = global.VisuDSA || {};
+  global.VisuDSA.algorithms = global.VisuDSA.algorithms || {};
+  global.VisuDSA.algorithms.binarySearch = binarySearch;
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/algorithms/binarySearch.nomod.js
+++ b/algorithms/binarySearch.nomod.js
@@ -1,7 +1,11 @@
 // Binary Search with step generator + pseudocode mapping (non-module build)
 (function (global) {
   function binarySearch(input) {
-    if (!input || !Array.isArray(input.array)) {
+    if (
+      !input ||
+      !Array.isArray(input.array) ||
+      typeof input.target !== 'number'
+    ) {
       throw new Error('binarySearch expects { array: number[], target: number }');
     }
     const { array: source, target } = input;

--- a/algorithms/bubbleSort.nomod.js
+++ b/algorithms/bubbleSort.nomod.js
@@ -1,0 +1,52 @@
+// Bubble Sort with step generator + pseudocode mapping (non-module build)
+(function (global) {
+  function bubbleSort(input) {
+    const arr = [...input];
+    const steps = [];
+    const pseudocode = [
+      'for i \u2190 0 to n-2',
+      '    swapped \u2190 false',
+      '    for j \u2190 0 to n-2-i',
+      '        if A[j] > A[j+1]',
+      '            swap A[j], A[j+1]',
+      '    if not swapped break'
+    ];
+
+    const meta = {
+      complexity: { best: 'O(n)', avg: 'O(n^2)', worst: 'O(n^2)' },
+      space: 'O(1)',
+      notes: 'Stable when implemented with adjacent swaps. Early-exit when the array is already sorted.'
+    };
+
+    function push(sel = [], compare = [], swap = [], hlLines = [1]) {
+      steps.push({ array: [...arr], sel, compare, swap, hlLines });
+    }
+
+    push([], [], [], [1]);
+
+    for (let i = 0; i < arr.length - 1; i++) {
+      let swapped = false;
+      push([arr.length - 1 - i], [], [], [1, 2]);
+      for (let j = 0; j < arr.length - 1 - i; j++) {
+        push([j], [j, j + 1], [], [3, 4]);
+        if (arr[j] > arr[j + 1]) {
+          const tmp = arr[j];
+          arr[j] = arr[j + 1];
+          arr[j + 1] = tmp;
+          swapped = true;
+          push([j + 1], [], [j, j + 1], [5]);
+        }
+      }
+      push([arr.length - 1 - i], [], [], [6]);
+      if (!swapped) break;
+    }
+
+    push([], [], [], [6]);
+
+    return { steps, pseudocode, meta };
+  }
+
+  global.VisuDSA = global.VisuDSA || {};
+  global.VisuDSA.algorithms = global.VisuDSA.algorithms || {};
+  global.VisuDSA.algorithms.bubbleSort = bubbleSort;
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/algorithms/dfs.nomod.js
+++ b/algorithms/dfs.nomod.js
@@ -61,8 +61,9 @@
         visited.add(v);
         arr[vIdx] = ++order;
         push([vIdx], [], [], [5, 6], { stack: [...stack], visited: Array.from(visited), current: v });
-        const neighbors = (graph[v] || []).slice().reverse();
-        for (const w of neighbors) {
+        const neighbors = graph[v] || [];
+        for (let i = neighbors.length - 1; i >= 0; i--) {
+          const w = neighbors[i];
           const wIdx = indexOf.get(w);
           push([vIdx], [wIdx], [], [7, 8], { stack: [...stack], visited: Array.from(visited), current: v, neighbor: w });
           if (!visited.has(w)) {

--- a/algorithms/dfs.nomod.js
+++ b/algorithms/dfs.nomod.js
@@ -1,0 +1,82 @@
+// Depth-First Search on adjacency list graph (non-module build)
+(function (global) {
+  function dfs(input) {
+    if (!input || typeof input !== 'object') {
+      throw new Error('dfs expects { graph: Record<string, string[]>, start: string }');
+    }
+    const { graph = {}, start } = input;
+    const nodes = Array.from(
+      new Set(
+        Object.keys(graph).concat(
+          ...Object.values(graph).map((neighbors) => neighbors ?? [])
+        )
+      )
+    );
+    if (nodes.length === 0) {
+      return { steps: [], pseudocode: [], meta: {} };
+    }
+    if (!nodes.includes(start)) {
+      throw new Error('Start vertex must exist in the graph.');
+    }
+
+    const indexOf = new Map(nodes.map((node, idx) => [node, idx]));
+    const arr = nodes.map(() => 0); // visitation order (0 = unvisited)
+    const steps = [];
+    const pseudocode = [
+      'create empty stack S',
+      'push(start)',
+      'while S not empty',
+      '    v \u2190 pop(S)',
+      '    if not visited[v]',
+      '        visited[v] \u2190 true',
+      '        for each neighbor w in reverse(Adj[v])',
+      '            if not visited[w]',
+      '                push(w)'
+    ];
+
+    const meta = {
+      complexity: { best: 'O(V + E)', avg: 'O(V + E)', worst: 'O(V + E)' },
+      space: 'O(V)',
+      notes: 'Iterative depth-first traversal using a stack. Reversing adjacency ensures natural recursion order.'
+    };
+
+    function push(sel = [], compare = [], swap = [], hlLines = [1], extra = {}) {
+      steps.push({ array: [...arr], sel, compare, swap, hlLines, nodes, ...extra });
+    }
+
+    const visited = new Set();
+    const stack = [];
+    let order = 0;
+
+    push([], [], [], [1], { stack: [...stack], visited: Array.from(visited) });
+
+    stack.push(start);
+    push([indexOf.get(start)], [], [], [2], { stack: [...stack], visited: Array.from(visited) });
+
+    while (stack.length) {
+      const v = stack.pop();
+      const vIdx = indexOf.get(v);
+      push([vIdx], [], [], [3, 4], { stack: [...stack], visited: Array.from(visited), current: v });
+      if (!visited.has(v)) {
+        visited.add(v);
+        arr[vIdx] = ++order;
+        push([vIdx], [], [], [5, 6], { stack: [...stack], visited: Array.from(visited), current: v });
+        const neighbors = (graph[v] || []).slice().reverse();
+        for (const w of neighbors) {
+          const wIdx = indexOf.get(w);
+          push([vIdx], [wIdx], [], [7, 8], { stack: [...stack], visited: Array.from(visited), current: v, neighbor: w });
+          if (!visited.has(w)) {
+            stack.push(w);
+            push([wIdx], [], [], [9], { stack: [...stack], visited: Array.from(visited), current: v, neighbor: w });
+          }
+        }
+      }
+    }
+
+    return { steps, pseudocode, meta };
+  }
+
+  global.VisuDSA = global.VisuDSA || {};
+  global.VisuDSA.algorithms = global.VisuDSA.algorithms || {};
+  global.VisuDSA.algorithms.dfs = dfs;
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/algorithms/mergeSort.nomod.js
+++ b/algorithms/mergeSort.nomod.js
@@ -1,0 +1,98 @@
+// Merge Sort with step generator + pseudocode mapping (non-module build)
+(function (global) {
+  function mergeSort(input) {
+    const arr = [...input];
+    const steps = [];
+    const pseudocode = [
+      'mergeSort(A, left, right)',
+      '    if left \u2265 right return',
+      '    mid \u2190 \u230a(left + right) / 2\u230b',
+      '    mergeSort(A, left, mid)',
+      '    mergeSort(A, mid+1, right)',
+      '    merge(A, left, mid, right)',
+      'merge(A, left, mid, right)',
+      '    i \u2190 left, j \u2190 mid+1, k \u2190 left',
+      '    while i \u2264 mid and j \u2264 right',
+      '        if A[i] \u2264 A[j]',
+      '            temp[k] \u2190 A[i]; i++',
+      '        else',
+      '            temp[k] \u2190 A[j]; j++',
+      '        k++',
+      '    copy remaining elements of left or right to temp',
+      '    copy temp[left..right] back into A'
+    ];
+
+    const meta = {
+      complexity: { best: 'O(n log n)', avg: 'O(n log n)', worst: 'O(n log n)' },
+      space: 'O(n)',
+      notes: 'Stable divide-and-conquer algorithm. Uses auxiliary array during merge.'
+    };
+
+    function push(sel = [], compare = [], swap = [], hlLines = [1]) {
+      steps.push({ array: [...arr], sel, compare, swap, hlLines });
+    }
+
+    push([], [], [], [1]);
+
+    const temp = new Array(arr.length);
+
+    function merge(left, mid, right) {
+      let i = left;
+      let j = mid + 1;
+      let k = left;
+      push(Array.from({ length: right - left + 1 }, (_, idx) => left + idx), [], [], [7, 8]);
+      while (i <= mid && j <= right) {
+        push([i, j], [i, j], [], [9, 10]);
+        if (arr[i] <= arr[j]) {
+          temp[k] = arr[i];
+          push([k], [], [i], [11]);
+          i++;
+        } else {
+          temp[k] = arr[j];
+          push([k], [], [j], [12, 13]);
+          j++;
+        }
+        k++;
+        push([k - 1], [], [], [14]);
+      }
+      while (i <= mid) {
+        temp[k] = arr[i];
+        push([k], [], [i], [15]);
+        i++;
+        k++;
+      }
+      while (j <= right) {
+        temp[k] = arr[j];
+        push([k], [], [j], [15]);
+        j++;
+        k++;
+      }
+      for (let idx = left; idx <= right; idx++) {
+        arr[idx] = temp[idx];
+        push([idx], [], [idx], [16]);
+      }
+    }
+
+    function sort(left, right) {
+      if (left >= right) {
+        push([left], [], [], [1, 2]);
+        return;
+      }
+      const mid = Math.floor((left + right) / 2);
+      push(Array.from({ length: right - left + 1 }, (_, idx) => left + idx), [], [], [1, 3]);
+      sort(left, mid);
+      sort(mid + 1, right);
+      merge(left, mid, right);
+    }
+
+    if (arr.length > 0) {
+      sort(0, arr.length - 1);
+    }
+
+    return { steps, pseudocode, meta };
+  }
+
+  global.VisuDSA = global.VisuDSA || {};
+  global.VisuDSA.algorithms = global.VisuDSA.algorithms || {};
+  global.VisuDSA.algorithms.mergeSort = mergeSort;
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/algorithms/quickSort.nomod.js
+++ b/algorithms/quickSort.nomod.js
@@ -1,0 +1,78 @@
+// Quick Sort with step generator + pseudocode mapping (non-module build)
+(function (global) {
+  function quickSort(input) {
+    const arr = [...input];
+    const steps = [];
+    const pseudocode = [
+      'quickSort(A, low, high)',
+      '    if low < high',
+      '        pivot \u2190 partition(A, low, high)',
+      '        quickSort(A, low, pivot-1)',
+      '        quickSort(A, pivot+1, high)',
+      'partition(A, low, high)',
+      '    pivotValue \u2190 A[high]',
+      '    i \u2190 low - 1',
+      '    for j \u2190 low to high-1',
+      '        if A[j] \u2264 pivotValue',
+      '            i \u2190 i + 1',
+      '            swap A[i], A[j]',
+      '    swap A[i+1], A[high]',
+      '    return i + 1'
+    ];
+
+    const meta = {
+      complexity: { best: 'O(n log n)', avg: 'O(n log n)', worst: 'O(n^2)' },
+      space: 'O(log n)',
+      notes: 'In-place, unstable. Worst case occurs on already sorted input with poor pivot choice.'
+    };
+
+    function push(sel = [], compare = [], swap = [], hlLines = [1]) {
+      steps.push({ array: [...arr], sel, compare, swap, hlLines });
+    }
+
+    push([], [], [], [1]);
+
+    function partition(low, high) {
+      const pivotValue = arr[high];
+      let i = low - 1;
+      push([high], [], [], [6, 7]);
+      for (let j = low; j < high; j++) {
+        push([low, high, i + 1], [j, high], [], [8, 9, 10]);
+        if (arr[j] <= pivotValue) {
+          i++;
+          const tmp = arr[i];
+          arr[i] = arr[j];
+          arr[j] = tmp;
+          push([i], [], [i, j], [11, 12]);
+        }
+      }
+      const tmp = arr[i + 1];
+      arr[i + 1] = arr[high];
+      arr[high] = tmp;
+      push([i + 1], [], [i + 1, high], [13]);
+      return i + 1;
+    }
+
+    function sort(low, high) {
+      if (low < high) {
+        push(Array.from({ length: high - low + 1 }, (_, idx) => low + idx), [], [], [1, 2]);
+        const pivot = partition(low, high);
+        push([pivot], [], [], [3]);
+        sort(low, pivot - 1);
+        sort(pivot + 1, high);
+      } else if (low === high) {
+        push([low], [], [], [1]);
+      }
+    }
+
+    if (arr.length > 0) {
+      sort(0, arr.length - 1);
+    }
+
+    return { steps, pseudocode, meta };
+  }
+
+  global.VisuDSA = global.VisuDSA || {};
+  global.VisuDSA.algorithms = global.VisuDSA.algorithms || {};
+  global.VisuDSA.algorithms.quickSort = quickSort;
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/algorithms/quickSort.nomod.js
+++ b/algorithms/quickSort.nomod.js
@@ -55,7 +55,7 @@
 
     function sort(low, high) {
       if (low < high) {
-        push(Array.from({ length: high - low + 1 }, (_, idx) => low + idx), [], [], [1, 2]);
+        push([low, high], [], [], [1, 2]);
         const pivot = partition(low, high);
         push([pivot], [], [], [3]);
         sort(low, pivot - 1);

--- a/algorithms/selectionSort.nomod.js
+++ b/algorithms/selectionSort.nomod.js
@@ -1,0 +1,55 @@
+// Selection Sort with step generator + pseudocode mapping (non-module build)
+(function (global) {
+  function selectionSort(input) {
+    const arr = [...input];
+    const steps = [];
+    const pseudocode = [
+      'for i \u2190 0 to n-2',
+      '    min \u2190 i',
+      '    for j \u2190 i+1 to n-1',
+      '        if A[j] < A[min]',
+      '            min \u2190 j',
+      '    swap A[i], A[min]'
+    ];
+
+    const meta = {
+      complexity: { best: 'O(n^2)', avg: 'O(n^2)', worst: 'O(n^2)' },
+      space: 'O(1)',
+      notes: 'Not stable by default. Always performs n(n-1)/2 comparisons regardless of input order.'
+    };
+
+    function push(sel = [], compare = [], swap = [], hlLines = [1]) {
+      steps.push({ array: [...arr], sel, compare, swap, hlLines });
+    }
+
+    push([], [], [], [1]);
+
+    for (let i = 0; i < arr.length - 1; i++) {
+      let min = i;
+      push([i], [], [], [1, 2]);
+      for (let j = i + 1; j < arr.length; j++) {
+        push([i, min], [j], [], [3, 4]);
+        if (arr[j] < arr[min]) {
+          min = j;
+          push([i, min], [], [], [5]);
+        }
+      }
+      if (min !== i) {
+        const tmp = arr[i];
+        arr[i] = arr[min];
+        arr[min] = tmp;
+        push([i, min], [], [i, min], [6]);
+      } else {
+        push([i], [], [], [6]);
+      }
+    }
+
+    push([], [], [], [6]);
+
+    return { steps, pseudocode, meta };
+  }
+
+  global.VisuDSA = global.VisuDSA || {};
+  global.VisuDSA.algorithms = global.VisuDSA.algorithms || {};
+  global.VisuDSA.algorithms.selectionSort = selectionSort;
+})(typeof window !== 'undefined' ? window : globalThis);


### PR DESCRIPTION
## Summary
- add non-module versions of bubble sort, selection sort, merge sort, and quick sort with step metadata
- provide binary search, BFS, and DFS generators that follow the shared visualization contract

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8d5e66dc883319c685f83a369a0e1