### PR TITLE
Enable algorithm switching and add bubble sort module

### DIFF
--- a/algorithms/bubbleSort.js
+++ b/algorithms/bubbleSort.js
@@ -8,7 +8,7 @@ export function bubbleSort(input) {
     '    for j ← 0 to n-2-i',
     '        if A[j] > A[j+1]',
     '            swap A[j], A[j+1]',
-    '    if not swapped break'
+    '    if not swapped then break'
   ];
 
   const meta = {

--- a/algorithms/bubbleSort.js
+++ b/algorithms/bubbleSort.js
@@ -1,0 +1,46 @@
+// Bubble Sort with step generator + pseudocode mapping (ES module)
+export function bubbleSort(input) {
+  const arr = [...input];
+  const steps = [];
+  const pseudocode = [
+    'for i ← 0 to n-2',
+    '    swapped ← false',
+    '    for j ← 0 to n-2-i',
+    '        if A[j] > A[j+1]',
+    '            swap A[j], A[j+1]',
+    '    if not swapped break'
+  ];
+
+  const meta = {
+    complexity: { best: 'O(n)', avg: 'O(n²)', worst: 'O(n²)' },
+    space: 'O(1)',
+    notes: 'Stable when implemented with adjacent swaps. Early-exit when the array is already sorted.'
+  };
+
+  function push(sel = [], compare = [], swap = [], hlLines = [1]) {
+    steps.push({ array: [...arr], sel, compare, swap, hlLines });
+  }
+
+  push([], [], [], [1]);
+
+  for (let i = 0; i < arr.length - 1; i++) {
+    let swapped = false;
+    push([arr.length - 1 - i], [], [], [1, 2]);
+    for (let j = 0; j < arr.length - 1 - i; j++) {
+      push([j], [j, j + 1], [], [3, 4]);
+      if (arr[j] > arr[j + 1]) {
+        const tmp = arr[j];
+        arr[j] = arr[j + 1];
+        arr[j + 1] = tmp;
+        swapped = true;
+        push([j + 1], [], [j, j + 1], [5]);
+      }
+    }
+    push([arr.length - 1 - i], [], [], [6]);
+    if (!swapped) break;
+  }
+
+  push([], [], [], [6]);
+
+  return { steps, pseudocode, meta };
+}

--- a/app.js
+++ b/app.js
@@ -1,9 +1,16 @@
 // Minimal VisuAlgo-like starter (vanilla JS, no build step)
 import { insertionSort } from './algorithms/insertionSort.js';
+import { bubbleSort } from './algorithms/bubbleSort.js';
 
 const algorithms = {
-  insertionSort
+  insertionSort,
+  bubbleSort
 };
+
+const formatName = (key) =>
+  key
+    .replace(/([A-Z])/g, ' $1')
+    .replace(/^./, (c) => c.toUpperCase());
 
 const algoSelect = document.getElementById('algoSelect');
 const randomBtn = document.getElementById('randomBtn');
@@ -22,6 +29,19 @@ const visual = document.getElementById('visual');
 const codePane = document.querySelector('#codePane code');
 const complexityBody = document.getElementById('complexityBody');
 const notesBody = document.getElementById('notesBody');
+
+function populateAlgorithmSelect() {
+  algoSelect.innerHTML = '';
+  Object.keys(algorithms).forEach((key, index) => {
+    const option = document.createElement('option');
+    option.value = key;
+    option.textContent = formatName(key);
+    if (index === 0) {
+      option.selected = true;
+    }
+    algoSelect.appendChild(option);
+  });
+}
 
 let steps = [];
 let run = null;
@@ -127,6 +147,12 @@ function playLoop() {
 }
 
 // Event handlers
+algoSelect.onchange = () => {
+  const arr = parseArray(arrayInput.value);
+  stopPlaying();
+  buildSteps(algoSelect.value, arr);
+};
+
 randomBtn.onclick = () => {
   const arr = randomArray(10);
   arrayInput.value = arr.join(', ');
@@ -173,4 +199,6 @@ playBtn.onclick = () => {
 };
 
 // Boot
-buildSteps('insertionSort', parseArray(arrayInput.value));
+populateAlgorithmSelect();
+const defaultAlgo = algoSelect.value || Object.keys(algorithms)[0];
+buildSteps(defaultAlgo, parseArray(arrayInput.value));

--- a/index.html
+++ b/index.html
@@ -10,9 +10,7 @@
   <header class="topbar">
     <h1>VisuDSA <span class="badge">starter</span></h1>
     <nav>
-      <select id="algoSelect" aria-label="Algorithm">
-        <option value="insertionSort">Insertion Sort</option>
-      </select>
+      <select id="algoSelect" aria-label="Algorithm"></select>
       <button id="randomBtn" title="Randomize input">🎲 Random</button>
       <input id="arrayInput" value="5,2,9,1,5,6" aria-label="Array input (comma-separated)" />
       <button id="loadBtn">Load</button>


### PR DESCRIPTION
## Summary
- add a module-based implementation of bubble sort with visualization metadata
- populate the algorithm selector from available modules and reload the visualization when changed
- keep the UI markup lean by letting JavaScript inject the available algorithms

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68d8d89f8f148331802a4e5325d4136e