### PR TITLE
Highlight quicksort partition colors in notes

### DIFF
--- a/algorithms/quickSort.js
+++ b/algorithms/quickSort.js
@@ -22,7 +22,129 @@ export function quickSort(input) {
   const meta = {
     complexity: { best: 'O(n log n)', avg: 'O(n log n)', worst: 'O(n²)' },
     space: 'O(log n)',
-    notes: 'In-place, unstable. Worst case occurs on already sorted input with poor pivot choice.'
+    notes: `
+      <div class="note-section">
+        <h3>Partition walk-through</h3>
+        <p>
+          Using the Lomuto scheme with the <em>last</em> element as the pivot, every call to
+          <code>partition(A, start, end)</code> moves that pivot into its final sorted position.
+          The example below shows the pivot index returned for <code>[27, 90, 2, 40, 45, 80, 10, 70, 85, 30]</code>.
+        </p>
+        <table class="note-table">
+          <thead>
+            <tr><th>Call</th><th>Subarray</th><th>Pivot index</th><th>Array after partition</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>1</td><td>[0, 9]</td><td>3</td><td><code>[27, 2, 10, 30, 45, 80, 90, 70, 85, 40]</code></td></tr>
+            <tr><td>2</td><td>[0, 2]</td><td>1</td><td><code>[2, 10, 27, 30, 45, 80, 90, 70, 85, 40]</code></td></tr>
+            <tr><td>3</td><td>[4, 9]</td><td>4</td><td><code>[2, 10, 27, 30, 40, 80, 90, 70, 85, 45]</code></td></tr>
+            <tr><td>4</td><td>[5, 9]</td><td>5</td><td><code>[2, 10, 27, 30, 40, 45, 90, 70, 85, 80]</code></td></tr>
+            <tr><td>5</td><td>[6, 9]</td><td>7</td><td><code>[2, 10, 27, 30, 40, 45, 70, 80, 85, 90]</code></td></tr>
+            <tr><td>6</td><td>[8, 9]</td><td>9</td><td><code>[2, 10, 27, 30, 40, 45, 70, 80, 85, 90]</code></td></tr>
+          </tbody>
+        </table>
+        <div class="note-array-legend">
+          <span class="cell-label"><span class="cell-swatch cell-lte">≤ pivot</span> moved left</span>
+          <span class="cell-label"><span class="cell-swatch cell-gt">&gt; pivot</span> stays right</span>
+          <span class="cell-label"><span class="cell-swatch cell-unseen">unprocessed</span> pending scan</span>
+          <span class="cell-label"><span class="cell-swatch cell-pivot">pivot</span> last element</span>
+        </div>
+        <table class="note-table note-array-table">
+          <thead>
+            <tr>
+              <th scope="row">Index</th>
+              <th>0</th><th>1</th><th>2</th><th>3</th><th>4</th><th>5</th><th>6</th><th>7</th><th>8</th><th>9</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th scope="row">During scan (j = 3)</th>
+              <td><span class="cell cell-lte">27</span></td>
+              <td><span class="cell cell-gt">90</span></td>
+              <td><span class="cell cell-lte">2</span></td>
+              <td><span class="cell cell-gt">40</span></td>
+              <td><span class="cell cell-unseen">45</span></td>
+              <td><span class="cell cell-unseen">80</span></td>
+              <td><span class="cell cell-unseen">10</span></td>
+              <td><span class="cell cell-unseen">70</span></td>
+              <td><span class="cell cell-unseen">85</span></td>
+              <td><span class="cell cell-pivot">30</span></td>
+            </tr>
+            <tr>
+              <th scope="row">After partition</th>
+              <td><span class="cell cell-lte">27</span></td>
+              <td><span class="cell cell-lte">2</span></td>
+              <td><span class="cell cell-lte">10</span></td>
+              <td><span class="cell cell-pivot">30</span></td>
+              <td><span class="cell cell-gt">45</span></td>
+              <td><span class="cell cell-gt">80</span></td>
+              <td><span class="cell cell-gt">90</span></td>
+              <td><span class="cell cell-gt">70</span></td>
+              <td><span class="cell cell-gt">85</span></td>
+              <td><span class="cell cell-gt">40</span></td>
+            </tr>
+          </tbody>
+        </table>
+        <p class="note-footnote">Trace the scan row from left to right: each comparison either paints the slot green (≤ pivot) or leaves it red (> pivot). Once <code>j</code> reaches the end, the pivot trades places with the first red item, yielding the lower/upper partitions shown underneath.</p>
+      </div>
+      <div class="note-section">
+        <h3>Pivot improvements &amp; variations</h3>
+        <ul>
+          <li><strong>Median-of-three:</strong> choose the median of <code>A[low]</code>, <code>A[mid]</code>, <code>A[high]</code> and swap it into <code>A[high]</code>. This guards against already sorted inputs that trigger the quadratic worst case.</li>
+          <li><strong>Random pivot:</strong> pick a random index in <code>[low, high]</code> before partitioning. Expected runtime stays at <code>O(n log n)</code> even for adversarial input.</li>
+          <li><strong>Tail call elimination:</strong> always recurse on the smaller side first and loop over the larger side to keep the call stack at <code>O(log n)</code>.</li>
+          <li><strong>Insertion sort cutoff:</strong> for tiny subarrays (e.g., ≤ 8 elements) switch to insertion sort to cut the constant factors.</li>
+        </ul>
+        <p>With balanced partitions, the Master Theorem gives <code>T(n) = 2T(n/2) + Θ(n) = Θ(n log n)</code>. Unbalanced partitions (<code>T(n) = T(n-1) + Θ(n)</code>) degrade to <code>Θ(n²)</code>.</p>
+      </div>
+      <div class="note-section">
+        <h3>Median-of-three in practice</h3>
+        <p>The table shows the first call on the same array when the pivot is chosen via median-of-three.</p>
+        <table class="note-table">
+          <thead>
+            <tr><th>low</th><th>mid</th><th>high</th><th>Values</th><th>Median</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>0</td><td>4</td><td>9</td><td><code>[27, 45, 30]</code></td><td><code>30</code> → swapped into <code>A[high]</code></td></tr>
+          </tbody>
+        </table>
+        <p>Subsequent partitioning mirrors the Lomuto flow but avoids the degenerate pivot for sorted or reverse-sorted inputs.</p>
+      </div>
+      <div class="note-section">
+        <h3>Properties</h3>
+        <ul>
+          <li>Not stable – equal keys can swap their relative order.</li>
+          <li>In-place – only uses <code>O(log n)</code> extra stack frames on average.</li>
+          <li><strong>Quickselect:</strong> reuse <code>partition</code> but recurse only into the side that contains the k-th element. Average case <code>Θ(n)</code>, worst case <code>Θ(n²)</code>.</li>
+        </ul>
+      </div>
+      <div class="note-section">
+        <h3>Quickselect pseudocode</h3>
+        <pre><code>QuickSelect(A, k, start, end)
+    if start == end: return A[start]
+    pivotIndex ← partition(A, start, end)
+    if pivotIndex == k: return A[k]
+    if pivotIndex &gt; k: return QuickSelect(A, k, start, pivotIndex-1)
+    return QuickSelect(A, k, pivotIndex+1, end)</code></pre>
+      </div>
+      <div class="note-section">
+        <h3>Practice prompts</h3>
+        <ul>
+          <li>Trace the swap operations for two crafted inputs: one where every element is smaller than the pivot and one where every element is larger.</li>
+          <li>Experiment with the cutoff for switching to insertion sort – how does it affect comparisons on random arrays?</li>
+          <li>Implement median-of-three and random pivot variants, then compare recursion depth statistics.</li>
+        </ul>
+      </div>
+      <div class="note-section">
+        <h3>Resources</h3>
+        <ul>
+          <li><a href="https://visualgo.net/en/sorting" target="_blank" rel="noopener">VisuAlgo quicksort animation</a> – demonstrates different partition strategies.</li>
+          <li><a href="https://visualgo.net/en" target="_blank" rel="noopener">VisuAlgo (full site)</a> – interactive DSA reference.</li>
+          <li><a href="https://www.youtube.com/watch?v=PgBzjlCcFvg" target="_blank" rel="noopener">mycodeschool quicksort deep dive</a>.</li>
+          <li><a href="https://en.wikipedia.org/wiki/Quicksort" target="_blank" rel="noopener">Wikipedia overview</a> – historical context and proofs.</li>
+        </ul>
+      </div>
+    `.trim()
   };
 
   function push(sel = [], compare = [], swap = [], hlLines = [1], seg = null) {

--- a/algorithms/quickSort.nomod.js
+++ b/algorithms/quickSort.nomod.js
@@ -21,9 +21,131 @@
     ];
 
     const meta = {
-      complexity: { best: 'O(n log n)', avg: 'O(n log n)', worst: 'O(n^2)' },
+      complexity: { best: 'O(n log n)', avg: 'O(n log n)', worst: 'O(n²)' },
       space: 'O(log n)',
-      notes: 'In-place, unstable. Worst case occurs on already sorted input with poor pivot choice.'
+      notes: `
+      <div class="note-section">
+        <h3>Partition walk-through</h3>
+        <p>
+          Using the Lomuto scheme with the <em>last</em> element as the pivot, every call to
+          <code>partition(A, start, end)</code> moves that pivot into its final sorted position.
+          The example below shows the pivot index returned for <code>[27, 90, 2, 40, 45, 80, 10, 70, 85, 30]</code>.
+        </p>
+        <table class="note-table">
+          <thead>
+            <tr><th>Call</th><th>Subarray</th><th>Pivot index</th><th>Array after partition</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>1</td><td>[0, 9]</td><td>3</td><td><code>[27, 2, 10, 30, 45, 80, 90, 70, 85, 40]</code></td></tr>
+            <tr><td>2</td><td>[0, 2]</td><td>1</td><td><code>[2, 10, 27, 30, 45, 80, 90, 70, 85, 40]</code></td></tr>
+            <tr><td>3</td><td>[4, 9]</td><td>4</td><td><code>[2, 10, 27, 30, 40, 80, 90, 70, 85, 45]</code></td></tr>
+            <tr><td>4</td><td>[5, 9]</td><td>5</td><td><code>[2, 10, 27, 30, 40, 45, 90, 70, 85, 80]</code></td></tr>
+            <tr><td>5</td><td>[6, 9]</td><td>7</td><td><code>[2, 10, 27, 30, 40, 45, 70, 80, 85, 90]</code></td></tr>
+            <tr><td>6</td><td>[8, 9]</td><td>9</td><td><code>[2, 10, 27, 30, 40, 45, 70, 80, 85, 90]</code></td></tr>
+          </tbody>
+        </table>
+        <div class="note-array-legend">
+          <span class="cell-label"><span class="cell-swatch cell-lte">≤ pivot</span> moved left</span>
+          <span class="cell-label"><span class="cell-swatch cell-gt">&gt; pivot</span> stays right</span>
+          <span class="cell-label"><span class="cell-swatch cell-unseen">unprocessed</span> pending scan</span>
+          <span class="cell-label"><span class="cell-swatch cell-pivot">pivot</span> last element</span>
+        </div>
+        <table class="note-table note-array-table">
+          <thead>
+            <tr>
+              <th scope="row">Index</th>
+              <th>0</th><th>1</th><th>2</th><th>3</th><th>4</th><th>5</th><th>6</th><th>7</th><th>8</th><th>9</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th scope="row">During scan (j = 3)</th>
+              <td><span class="cell cell-lte">27</span></td>
+              <td><span class="cell cell-gt">90</span></td>
+              <td><span class="cell cell-lte">2</span></td>
+              <td><span class="cell cell-gt">40</span></td>
+              <td><span class="cell cell-unseen">45</span></td>
+              <td><span class="cell cell-unseen">80</span></td>
+              <td><span class="cell cell-unseen">10</span></td>
+              <td><span class="cell cell-unseen">70</span></td>
+              <td><span class="cell cell-unseen">85</span></td>
+              <td><span class="cell cell-pivot">30</span></td>
+            </tr>
+            <tr>
+              <th scope="row">After partition</th>
+              <td><span class="cell cell-lte">27</span></td>
+              <td><span class="cell cell-lte">2</span></td>
+              <td><span class="cell cell-lte">10</span></td>
+              <td><span class="cell cell-pivot">30</span></td>
+              <td><span class="cell cell-gt">45</span></td>
+              <td><span class="cell cell-gt">80</span></td>
+              <td><span class="cell cell-gt">90</span></td>
+              <td><span class="cell cell-gt">70</span></td>
+              <td><span class="cell cell-gt">85</span></td>
+              <td><span class="cell cell-gt">40</span></td>
+            </tr>
+          </tbody>
+        </table>
+        <p class="note-footnote">Trace the scan row from left to right: each comparison either paints the slot green (≤ pivot) or leaves it red (> pivot). Once <code>j</code> reaches the end, the pivot trades places with the first red item, yielding the lower/upper partitions shown underneath.</p>
+      </div>
+        <div class="note-section">
+          <h3>Pivot improvements &amp; variations</h3>
+          <ul>
+            <li><strong>Median-of-three:</strong> choose the median of <code>A[low]</code>, <code>A[mid]</code>, <code>A[high]</code> and swap it into <code>A[high]</code>. This guards against already sorted inputs that trigger the quadratic worst case.</li>
+            <li><strong>Random pivot:</strong> pick a random index in <code>[low, high]</code> before partitioning. Expected runtime stays at <code>O(n log n)</code> even for adversarial input.</li>
+            <li><strong>Tail call elimination:</strong> always recurse on the smaller side first and loop over the larger side to keep the call stack at <code>O(log n)</code>.</li>
+            <li><strong>Insertion sort cutoff:</strong> for tiny subarrays (e.g., ≤ 8 elements) switch to insertion sort to cut the constant factors.</li>
+          </ul>
+          <p>With balanced partitions, the Master Theorem gives <code>T(n) = 2T(n/2) + Θ(n) = Θ(n log n)</code>. Unbalanced partitions (<code>T(n) = T(n-1) + Θ(n)</code>) degrade to <code>Θ(n²)</code>.</p>
+        </div>
+        <div class="note-section">
+          <h3>Median-of-three in practice</h3>
+          <p>The table shows the first call on the same array when the pivot is chosen via median-of-three.</p>
+          <table class="note-table">
+            <thead>
+              <tr><th>low</th><th>mid</th><th>high</th><th>Values</th><th>Median</th></tr>
+            </thead>
+            <tbody>
+              <tr><td>0</td><td>4</td><td>9</td><td><code>[27, 45, 30]</code></td><td><code>30</code> → swapped into <code>A[high]</code></td></tr>
+            </tbody>
+          </table>
+          <p>Subsequent partitioning mirrors the Lomuto flow but avoids the degenerate pivot for sorted or reverse-sorted inputs.</p>
+        </div>
+        <div class="note-section">
+          <h3>Properties</h3>
+          <ul>
+            <li>Not stable – equal keys can swap their relative order.</li>
+            <li>In-place – only uses <code>O(log n)</code> extra stack frames on average.</li>
+            <li><strong>Quickselect:</strong> reuse <code>partition</code> but recurse only into the side that contains the k-th element. Average case <code>Θ(n)</code>, worst case <code>Θ(n²)</code>.</li>
+          </ul>
+        </div>
+        <div class="note-section">
+          <h3>Quickselect pseudocode</h3>
+          <pre><code>QuickSelect(A, k, start, end)
+    if start == end: return A[start]
+    pivotIndex ← partition(A, start, end)
+    if pivotIndex == k: return A[k]
+    if pivotIndex &gt; k: return QuickSelect(A, k, start, pivotIndex-1)
+    return QuickSelect(A, k, pivotIndex+1, end)</code></pre>
+        </div>
+        <div class="note-section">
+          <h3>Practice prompts</h3>
+          <ul>
+            <li>Trace the swap operations for two crafted inputs: one where every element is smaller than the pivot and one where every element is larger.</li>
+            <li>Experiment with the cutoff for switching to insertion sort – how does it affect comparisons on random arrays?</li>
+            <li>Implement median-of-three and random pivot variants, then compare recursion depth statistics.</li>
+          </ul>
+        </div>
+        <div class="note-section">
+          <h3>Resources</h3>
+          <ul>
+            <li><a href="https://visualgo.net/en/sorting" target="_blank" rel="noopener">VisuAlgo quicksort animation</a> – demonstrates different partition strategies.</li>
+            <li><a href="https://visualgo.net/en" target="_blank" rel="noopener">VisuAlgo (full site)</a> – interactive DSA reference.</li>
+            <li><a href="https://www.youtube.com/watch?v=PgBzjlCcFvg" target="_blank" rel="noopener">mycodeschool quicksort deep dive</a>.</li>
+            <li><a href="https://en.wikipedia.org/wiki/Quicksort" target="_blank" rel="noopener">Wikipedia overview</a> – historical context and proofs.</li>
+          </ul>
+        </div>
+      `.trim()
     };
 
     function push(sel = [], compare = [], swap = [], hlLines = [1]) {

--- a/styles.css
+++ b/styles.css
@@ -129,6 +129,30 @@ svg .edge-label{fill:#9fb0d1;font-size:11px;font-weight:600}
 .complexity td{border-bottom:1px solid #1f2a44;padding:6px 4px;color:#cfe1ff}
 .complexity td:first-child{color:var(--muted)}
 .notes{margin-top:8px;color:#cfe1ff}
+.notes .note-section{margin-top:12px}
+.notes .note-section:first-child{margin-top:0}
+.notes h3{margin:0 0 6px;color:#9fb0d1;font-size:15px;font-weight:600}
+.notes p{margin:4px 0 8px;line-height:1.4}
+.notes ul{margin:6px 0 10px 18px;padding:0}
+.notes li{margin-bottom:4px}
+.notes code{background:#111a2f;color:#e7eefc;padding:0 4px;border-radius:4px;font-size:0.9em}
+.notes pre{background:#0f1627;border:1px solid #1f2a44;border-radius:6px;padding:10px;font-size:13px;line-height:1.5;overflow-x:auto}
+.notes table{width:100%;border-collapse:collapse;margin:6px 0 12px;font-size:13px}
+.notes th,.notes td{border:1px solid #1f2a44;padding:6px;text-align:left;vertical-align:top}
+.notes thead th{background:#101a33;color:#9fb0d1}
+.notes tbody tr:nth-child(even){background:rgba(15,22,39,0.6)}
+.notes .note-array-legend{display:flex;flex-wrap:wrap;gap:12px;margin:8px 0 4px;color:var(--muted);font-size:12px}
+.notes .note-array-legend .cell-label{display:flex;align-items:center;gap:6px}
+.notes .note-array-legend .cell-swatch{display:inline-flex;align-items:center;justify-content:center;min-width:72px;padding:4px 8px;border-radius:6px;font-weight:600}
+.notes .note-array-table th[scope="row"]{background:#0f1627;color:#9fb0d1;font-weight:600;width:88px}
+.notes .note-array-table tbody tr:nth-child(even){background:transparent}
+.notes .note-array-table td{vertical-align:middle;text-align:center}
+.notes .note-array-table .cell{display:inline-flex;align-items:center;justify-content:center;width:100%;padding:6px 0;border-radius:6px;font-weight:700}
+.notes .cell-lte{background:rgba(126,231,135,0.35);color:#0b2612}
+.notes .cell-gt{background:rgba(255,107,107,0.35);color:#2a0606}
+.notes .cell-unseen{background:rgba(159,176,209,0.25);color:#0b1220}
+.notes .cell-pivot{background:rgba(255,209,102,0.6);color:#2a1c00;box-shadow:inset 0 0 0 1px rgba(255,209,102,0.6)}
+.notes .note-footnote{margin:4px 0 0;font-size:12px;color:var(--muted)}
 .foot{color:var(--muted);text-align:center;padding:16px}
 @media (max-width: 980px){
 	.grid{grid-template-columns:1fr}


### PR DESCRIPTION
## Summary
- add a color-coded partition legend and dual snapshot table to the quicksort notes so the pivot and ≤/> segments are easy to follow
- mirror the enriched quicksort explanation in the non-module bundle
- extend the shared notes styles with reusable swatches for the legend, grid cells, and footnotes

## Testing
- not run (static content changes)


------
https://chatgpt.com/codex/tasks/task_e_68d9c4b643048331b04eac6940eec914