### PR TITLE
Fix quick sort recursion tree connectors and mobile table layout

### DIFF
--- a/app.js
+++ b/app.js
@@ -1002,7 +1002,7 @@ function renderRecursionTree(partitionCalls) {
           `[${truncateArray(node.subarrayElements)}]` :
           node.subarray;
 
-        const parentCall = node.parentCall == null ? 'root' : node.parentCall;
+        const parentCall = (node.parentCall === null || node.parentCall === undefined) ? 'root' : node.parentCall;
 
         treeHTML += `
           <div class="triangle-node-container" data-position="${nodePosition}" style="--node-position: ${nodePosition}">

--- a/app.js
+++ b/app.js
@@ -830,6 +830,10 @@ function renderInteractiveQuickSortTables() {
   
   if (partitionTable) {
     partitionTable.innerHTML = renderPartitionCallsTable(step);
+    requestAnimationFrame(() => {
+      const treeContainer = partitionTable.querySelector('.triangle-tree-container');
+      if (treeContainer) layoutRecursionTreeConnections(treeContainer);
+    });
   }
   
   if (arrayTable) {
@@ -940,15 +944,6 @@ function renderRecursionTree(partitionCalls) {
     parentOverlap = 32;
   }
 
-  const buildConnectionStyle = (parentPosition, childPosition) => {
-    const dx = (childPosition - parentPosition) * horizontalSpacing;
-    const dy = verticalSpacing + parentOverlap;
-    const angle = Math.atan2(dx, dy) * (180 / Math.PI);
-    const length = Math.sqrt(dx * dx + dy * dy);
-    const xOffset = parentPosition * horizontalSpacing;
-    return `--x-offset: ${xOffset}px; --angle: ${angle.toFixed(2)}deg; --length: ${length.toFixed(2)}px; --start-offset: ${parentOverlap}px;`;
-  };
-
   // Get the original array from the first partition call
   const originalArray = partitionCalls.length > 0 ? (partitionCalls[0].arrayBefore ?? []) : [];
 
@@ -963,7 +958,7 @@ function renderRecursionTree(partitionCalls) {
     leftElements: call.leftElements || [],
     rightElements: call.rightElements || []
   }));
-  
+
   // Helper function to truncate long arrays for better tree visualization
   const truncateArray = (elements, maxElements = 5) => {
     if (elements.length <= maxElements) {
@@ -974,10 +969,11 @@ function renderRecursionTree(partitionCalls) {
     return `${shown.join(', ')}, ... (+${remaining})`;
   };
 
-  // Create triangle tree visualization with slanted edges
+  // Create triangle tree visualization
   const maxLevel = Math.max(...treeNodes.map(n => n.level));
   let treeHTML = `<div class="triangle-tree-container" style="--triangle-horizontal-spacing: ${horizontalSpacing}px; --triangle-vertical-gap: ${verticalSpacing}px; --triangle-parent-overlap: ${parentOverlap}px; --triangle-block-gap: ${blockGap}px;">`;
-  
+  treeHTML += '<svg class="triangle-tree-lines" aria-hidden="true"></svg>';
+
   // Add the original array as root node at the top
   treeHTML += `
     <div class="triangle-tree-level triangle-level-root">
@@ -989,98 +985,111 @@ function renderRecursionTree(partitionCalls) {
       </div>
     </div>
   `;
-  
-  // Add connections from root to level 0 nodes
-  const level0Nodes = treeNodes.filter(n => n.level === 0);
-  if (level0Nodes.length > 0) {
-    treeHTML += `<div class="tree-connections-level" style="--level-gap: ${verticalSpacing}px;">`;
 
-    level0Nodes.forEach((node, index) => {
-      // Only connect nodes that have parentCall === null (direct children of root)
-      if (node.parentCall === null) {
-        const childPosition = index - (level0Nodes.length - 1) / 2;
-        const parentPosition = 0; // Root is always at center
-        const isLeft = childPosition < parentPosition;
-        const connectionClass = isLeft ? 'left-connection' : 'right-connection';
-
-        treeHTML += `
-          <div class="tree-connection ${connectionClass}"
-               style="${buildConnectionStyle(parentPosition, childPosition)}">
-          </div>
-        `;
-      }
-    });
-    
-    treeHTML += '</div>';
-  }
-  
   // Build tree levels in triangle formation
   for (let level = 0; level <= maxLevel; level++) {
     const nodesAtLevel = treeNodes.filter(n => n.level === level);
     if (nodesAtLevel.length > 0) {
       treeHTML += `<div class="triangle-tree-level triangle-level-${level}">`;
-      
+
       nodesAtLevel.forEach((node, index) => {
         // Calculate horizontal position for triangle layout
         const totalNodes = nodesAtLevel.length;
         const nodePosition = index - (totalNodes - 1) / 2; // Center around 0
-        
+
         // Create the elements display for this node
-        const elementsStr = node.subarrayElements.length > 0 ? 
-          `[${truncateArray(node.subarrayElements)}]` : 
+        const elementsStr = node.subarrayElements.length > 0 ?
+          `[${truncateArray(node.subarrayElements)}]` :
           node.subarray;
-        
+
+        const parentCall = node.parentCall == null ? 'root' : node.parentCall;
+
         treeHTML += `
           <div class="triangle-node-container" data-position="${nodePosition}" style="--node-position: ${nodePosition}">
-            <div class="triangle-node" data-call="${node.call}" onclick="highlightTableRow(${node.call})">
+            <div class="triangle-node" data-call="${node.call}" data-parent="${parentCall}" data-level="${node.level}" onclick="highlightTableRow(${node.call})">
               <div class="node-elements">${elementsStr}</div>
               <div class="node-pivot">pivot = ${node.pivotValue}</div>
             </div>
           </div>
         `;
       });
-      
+
       treeHTML += '</div>';
-      
-      // Add connection lines to the next level
-      if (level < maxLevel) {
-        const nextLevelNodes = treeNodes.filter(n => n.level === level + 1);
-        if (nextLevelNodes.length > 0) {
-          treeHTML += `<div class="tree-connections-level" style="--level-gap: ${verticalSpacing}px;">`;
-
-          // Create connections for each node at current level
-          nodesAtLevel.forEach((node, index) => {
-            const childNodes = nextLevelNodes.filter(n => n.parentCall === node.call);
-            if (childNodes.length > 0) {
-              const parentPosition = index - (nodesAtLevel.length - 1) / 2;
-              
-              childNodes.forEach((child, childIndex) => {
-                const childNodeIndex = nextLevelNodes.indexOf(child);
-                const childPosition = childNodeIndex - (nextLevelNodes.length - 1) / 2;
-
-                // Determine connection direction based on relative position
-                const isLeft = childPosition < parentPosition;
-                const connectionClass = isLeft ? 'left-connection' : 'right-connection';
-
-                treeHTML += `
-                  <div class="tree-connection ${connectionClass}"
-                       style="${buildConnectionStyle(parentPosition, childPosition)}">
-                  </div>
-                `;
-              });
-            }
-          });
-          
-          treeHTML += '</div>';
-        }
-      }
     }
   }
-  
+
   treeHTML += '</div>';
+
   return treeHTML;
 }
 
+function layoutRecursionTreeConnections(container) {
+  if (!container || typeof container.querySelector !== 'function') return;
+
+  let svg = container.querySelector('.triangle-tree-lines');
+  if (!svg) {
+    svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.classList.add('triangle-tree-lines');
+    container.insertBefore(svg, container.firstChild);
+  }
+
+  const rootNode = container.querySelector('.root-node .triangle-node');
+  const nodeElements = Array.from(container.querySelectorAll('.triangle-tree-level .triangle-node'));
+  if (!rootNode && nodeElements.length === 0) {
+    svg.innerHTML = '';
+    return;
+  }
+
+  const containerRect = container.getBoundingClientRect();
+  const width = container.scrollWidth;
+  const height = container.scrollHeight;
+  svg.setAttribute('width', width);
+  svg.setAttribute('height', height);
+  svg.setAttribute('viewBox', `0 0 ${width} ${height}`);
+  svg.style.width = `${width}px`;
+  svg.style.height = `${height}px`;
+  while (svg.firstChild) svg.firstChild.remove();
+
+  const nodeMap = new Map();
+  nodeElements.forEach(node => {
+    const id = node.dataset.call;
+    if (id) nodeMap.set(id, node);
+  });
+
+  nodeElements.forEach(node => {
+    const parentId = node.dataset.parent;
+    if (!parentId || node.dataset.call === 'root') return;
+
+    const parentNode = parentId === 'root' ? rootNode : nodeMap.get(parentId);
+    if (!parentNode) return;
+
+    const parentRect = parentNode.getBoundingClientRect();
+    const childRect = node.getBoundingClientRect();
+
+    const x1 = parentRect.left + parentRect.width / 2 - containerRect.left;
+    const y1 = parentRect.bottom - containerRect.top;
+    const x2 = childRect.left + childRect.width / 2 - containerRect.left;
+    const y2 = childRect.top - containerRect.top;
+
+    const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+    line.setAttribute('x1', x1);
+    line.setAttribute('y1', y1);
+    line.setAttribute('x2', x2);
+    line.setAttribute('y2', y2);
+    line.setAttribute('class', 'tree-connection-line');
+    svg.appendChild(line);
+  });
+}
+
+let recursionTreeResizeRaf = null;
+window.addEventListener('resize', () => {
+  if (recursionTreeResizeRaf) cancelAnimationFrame(recursionTreeResizeRaf);
+  recursionTreeResizeRaf = requestAnimationFrame(() => {
+    document.querySelectorAll('.triangle-tree-container').forEach(container => {
+      layoutRecursionTreeConnections(container);
+    });
+  });
+});
 function highlightTableRow(callNumber) {
   // Remove previous highlights
   document.querySelectorAll('.partition-call-row').forEach(row => {

--- a/app.js
+++ b/app.js
@@ -1058,7 +1058,7 @@ function layoutRecursionTreeConnections(container) {
 
   nodeElements.forEach(node => {
     const parentId = node.dataset.parent;
-    if (!parentId || node.dataset.call === 'root') return;
+    if (!parentId || parentId === 'root') return;
 
     const parentNode = parentId === 'root' ? rootNode : nodeMap.get(parentId);
     if (!parentNode) return;

--- a/styles.css
+++ b/styles.css
@@ -233,12 +233,31 @@ svg .edge-label{fill:#9fb0d1;font-size:11px;font-weight:600}
     position: relative;
 }
 
+.triangle-tree-lines {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    overflow: visible;
+    z-index: 0;
+}
+
+.triangle-tree-lines .tree-connection-line {
+    stroke: #7b8fc0;
+    stroke-width: 2.4px;
+    stroke-linecap: round;
+    opacity: 0.9;
+    filter: drop-shadow(0 2px 4px rgba(0,0,0,0.35));
+}
+
 .triangle-tree-level {
     display: flex;
     justify-content: center;
     align-items: center;
     position: relative;
     gap: 40px;
+    z-index: 1;
 }
 
 .triangle-level-root {
@@ -251,6 +270,7 @@ svg .edge-label{fill:#9fb0d1;font-size:11px;font-weight:600}
     flex-direction: column;
     align-items: center;
     transform: translateX(calc(var(--node-position, 0) * var(--triangle-horizontal-spacing)));
+    z-index: 1;
 }
 
 .triangle-node {
@@ -315,93 +335,6 @@ svg .edge-label{fill:#9fb0d1;font-size:11px;font-weight:600}
     font-style: italic;
 }
 
-.slanted-connection {
-    position: absolute;
-    top: 100%;
-    left: 50%;
-    transform-origin: 0 0;
-    pointer-events: none;
-    z-index: 1;
-    width: 2px;
-    height: 60px;
-    transform: translateX(-1px);
-}
-
-.slanted-connection::before {
-    content: '';
-    position: absolute;
-    width: 2px;
-    height: 60px;
-    background: linear-gradient(180deg, #3a4d7a 0%, #5a6d9a 100%);
-    transform-origin: 0 0;
-    box-shadow: 0 1px 3px rgba(0,0,0,0.3);
-}
-
-.left-connection::before {
-    background: linear-gradient(180deg, #3a4d7a 0%, #7a8ba3 100%);
-    transform: rotate(-30deg);
-}
-
-.right-connection::before {
-    background: linear-gradient(180deg, #7a8ba3 0%, #3a4d7a 100%);
-    transform: rotate(30deg);
-}
-
-/* Tree connections between levels */
-.tree-connections-level {
-    position: relative;
-    height: var(--level-gap, var(--triangle-vertical-gap));
-    overflow: visible;
-    z-index: 1;
-    width: 100%;
-}
-
-.tree-connection {
-    position: absolute;
-    top: 0;
-    width: 2px;
-    pointer-events: none;
-    left: 50%;
-    transform: translateX(calc(var(--x-offset, 0px) - 1.5px));
-}
-
-.tree-connection::before {
-    content: '';
-    position: absolute;
-    width: 3px;
-    height: calc(var(--length, 100px) + var(--start-offset, 0px));
-    background: linear-gradient(180deg, #6a7daa 0%, #8a9dca 100%);
-    transform-origin: top center;
-    transform: rotate(var(--angle, 0deg));
-    box-shadow: 0 1px 3px rgba(0,0,0,0.3);
-    opacity: 1;
-    border-radius: 1px;
-    top: calc(var(--start-offset, 0px) * -1);
-    left: 0;
-}
-
-.triangle-tree-level + .tree-connections-level {
-    margin-top: -18px;
-}
-
-.tree-connections-level {
-    margin-bottom: -18px;
-}
-
-.tree-connection.left-connection {
-}
-
-.tree-connection.left-connection::before {
-    background: linear-gradient(145deg, #6a7daa 0%, #8a9dca 100%);
-}
-
-.tree-connection.right-connection {
-}
-
-.tree-connection.right-connection::before {
-    background: linear-gradient(215deg, #8a9dca 0%, #6a7daa 100%);
-}
-
 /* Enhanced partition table */
 .partition-table{font-size:12px;margin-top:12px;width:100%;border-collapse:collapse}
 .partition-table th{font-size:11px;padding:8px 4px}
@@ -441,10 +374,10 @@ svg .edge-label{fill:#9fb0d1;font-size:11px;font-weight:600}
         /* Mobile partition table optimizations */
         .partition-table{display:block;font-size:11px;border-collapse:separate;border-spacing:0;overflow:visible}
         .partition-table thead{display:none}
-        .partition-table tbody{display:flex;flex-direction:column;gap:12px;width:100%}
-        .partition-table tr{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:8px 12px;background:rgba(16,26,51,0.85);border:1px solid #1f2a44;border-radius:12px;padding:10px}
-        .partition-table td{display:flex;flex-direction:column;padding:0;border:none;min-width:0;white-space:normal}
-        .partition-table td::before{content:attr(data-label);font-size:10px;font-weight:600;color:#9fb0d1;margin-bottom:2px;text-transform:uppercase;letter-spacing:0.03em}
+        .partition-table tbody{display:flex;flex-direction:column;gap:10px;width:100%;max-height:55vh;overflow-y:auto;padding-right:2px}
+        .partition-table tr{display:grid;grid-template-columns:repeat(auto-fit,minmax(120px,1fr));grid-auto-flow:row;gap:6px 10px;background:rgba(16,26,51,0.85);border:1px solid #1f2a44;border-radius:12px;padding:8px 10px}
+        .partition-table td{display:flex;flex-direction:column;padding:0;border:none;min-width:0;white-space:normal;font-size:10px}
+        .partition-table td::before{content:attr(data-label);font-size:9px;font-weight:600;color:#9fb0d1;margin-bottom:2px;text-transform:uppercase;letter-spacing:0.03em}
         .partition-table td.partition-span { grid-column: 1 / -1; }
         .partition-table td code{display:block}
         .partition-call-row.highlighted{box-shadow:0 0 0 1px rgba(113,183,255,0.6)}
@@ -470,13 +403,10 @@ svg .edge-label{fill:#9fb0d1;font-size:11px;font-weight:600}
                 font-size: 10px;
         }
 
-        .triangle-tree-level + .tree-connections-level{margin-top:-14px}
-        .tree-connections-level{margin-bottom:-14px}
-	
-	.triangle-node .node-elements {
-		font-size: 10px;
-		line-height: 1.1;
-	}
+        .triangle-node .node-elements {
+                font-size: 10px;
+                line-height: 1.1;
+        }
 	
 	.triangle-node .node-pivot {
 		font-size: 8px;
@@ -514,10 +444,7 @@ svg .edge-label{fill:#9fb0d1;font-size:11px;font-weight:600}
                 border-radius: 12px;
         }
 
-        .triangle-tree-level + .tree-connections-level{margin-top:-12px}
-        .tree-connections-level{margin-bottom:-12px}
-
-        .partition-table tr{grid-template-columns:1fr}
+        .partition-table tr{grid-template-columns:repeat(2,minmax(0,1fr))}
         .partition-table td{padding-bottom:6px}
         .partition-table td:last-child{padding-bottom:0}
 
@@ -538,7 +465,4 @@ svg .edge-label{fill:#9fb0d1;font-size:11px;font-weight:600}
 		font-size: 10px;
 	}
 	
-	.slanted-connection::before {
-		height: 30px;
-	}
 }


### PR DESCRIPTION
## Summary
- draw recursion tree connections with an SVG overlay so lines originate from the bottom center of each parent and terminate at the top center of each child
- refresh the partition table layout on small screens to show more calls at once via tighter spacing, auto-fit columns, and a scrollable body

## Testing
- Manual: loaded the Quick Sort visualization, ran it to completion, expanded the Notes section, and verified the recursion tree connectors and partition table on desktop sizing

------
https://chatgpt.com/codex/tasks/task_e_68dc76c9e06483319dd7c63ce62b0025